### PR TITLE
Enables adb NixOS module, adds user to appropriate group.

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -100,6 +100,7 @@
     ];
 
   programs = {
+    adb.enable = true;
     git = {
       config = {
         alias.lg =
@@ -171,9 +172,9 @@
     isNormalUser = true;
     description = "Admin";
     extraGroups = [
+      "adbusers"
       "dialout"
       "i2c"
-      "plugdev"
       "networkmanager"
       "video"
       "wheel"


### PR DESCRIPTION
This ought to fix the adb permissions issues? Might require a reboot after installing to make the relevant UDev rules take effect, not sure.